### PR TITLE
[Migration] Replace .basic to .support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ DerivedData/
 *Generated/
 Package.resolved
 .swiftlint/
-
-# SwiftLint Remote Config Cache
 .swiftlint/RemoteConfigCache
+.home/
+.spmComponentDerivedData/
+.sparkans/

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,3 +2,4 @@ parent_config: https://raw.githubusercontent.com/leboncoin/spark-ios-common/main
 
 excluded:
   - "**/*.generated.swift"
+  - ".build/"

--- a/Sources/Core/Model/PopoverIntent.swift
+++ b/Sources/Core/Model/PopoverIntent.swift
@@ -15,7 +15,6 @@ public enum PopoverIntent: CaseIterable {
     case main
     case support
     case accent
-    case basic
     case success
     case alert
     case error

--- a/Sources/Core/UseCase/GetColors/PopoverGetColorsUseCase.swift
+++ b/Sources/Core/UseCase/GetColors/PopoverGetColorsUseCase.swift
@@ -27,20 +27,15 @@ final class PopoverGetColorsUseCase: PopoverGetColorsUseCasable {
                 background: colors.main.mainContainer,
                 foreground: colors.main.onMainContainer
             )
-        case .support:
-            return .init(
-                background: colors.support.supportContainer,
-                foreground: colors.support.onSupportContainer
-            )
         case .accent:
             return .init(
                 background: colors.accent.accentContainer,
                 foreground: colors.accent.onAccentContainer
             )
-        case .basic:
+        case .support:
             return .init(
-                background: colors.basic.basicContainer,
-                foreground: colors.basic.onBasicContainer
+                background: colors.support.supportContainer,
+                foreground: colors.support.onSupportContainer
             )
         case .success:
             return .init(

--- a/Tests/UnitTests/UseCase/GetColors/PopoverGetColorsUseCaseTests.swift
+++ b/Tests/UnitTests/UseCase/GetColors/PopoverGetColorsUseCaseTests.swift
@@ -52,15 +52,6 @@ final class PopoverGetColorsUseCaseTests: XCTestCase {
         XCTAssertTrue(colors.foreground.equals(self.theme.colors.accent.onAccentContainer), "Wrong foreground color for intent .accent")
     }
 
-    func test_basic() {
-        // WHEN
-        let colors = self.useCase.execute(colors: self.theme.colors, intent: .basic)
-
-        // THEN
-        XCTAssertTrue(colors.background.equals(self.theme.colors.basic.basicContainer), "Wrong background color for intent .basic")
-        XCTAssertTrue(colors.foreground.equals(self.theme.colors.basic.onBasicContainer), "Wrong foreground color for intent .basic")
-    }
-
     func test_success() {
         // WHEN
         let colors = self.useCase.execute(colors: self.theme.colors, intent: .success)

--- a/Tests/UnitTests/ViewModel/PopoverViewModelTests.swift
+++ b/Tests/UnitTests/ViewModel/PopoverViewModelTests.swift
@@ -20,7 +20,7 @@ final class PopoverViewModelTests: XCTestCase {
         let getColorsUseCaseMock = PopoverGetColorsUseCasableGeneratedMock()
         getColorsUseCaseMock.executeWithColorsAndIntentReturnValue = .init(
             background: self.theme.colors.feedback.alertContainer,
-            foreground: self.theme.colors.basic.basicContainer
+            foreground: self.theme.colors.support.supportContainer
         )
 
         let getSpacesUseCaseMock = PopoverGetSpacesUseCasableGeneratedMock()
@@ -32,7 +32,7 @@ final class PopoverViewModelTests: XCTestCase {
         // WHEN
         let viewModel = PopoverViewModel(
             theme: self.theme,
-            intent: .basic,
+            intent: .support,
             showArrow: true,
             getColorsUseCase: getColorsUseCaseMock,
             getSpacesUseCase: getSpacesUseCaseMock
@@ -40,7 +40,7 @@ final class PopoverViewModelTests: XCTestCase {
 
         // THEN - Values
         XCTAssertTrue(viewModel.colors.background.equals(self.theme.colors.feedback.alertContainer), "Wrong colors.background")
-        XCTAssertTrue(viewModel.colors.foreground.equals(self.theme.colors.basic.basicContainer), "Wrong colors.foreground")
+        XCTAssertTrue(viewModel.colors.foreground.equals(self.theme.colors.support.supportContainer), "Wrong colors.foreground")
 
         XCTAssertEqual(viewModel.spaces.horizontal, 4.0, "Wrong spaces.horizontal")
         XCTAssertEqual(viewModel.spaces.vertical, 2.0, "Wrong spaces.vertical")
@@ -57,7 +57,7 @@ final class PopoverViewModelTests: XCTestCase {
             self.theme.colors as? ColorsGeneratedMock,
             "Wrong getColorsUseCaseReceivedArguments.colors"
         )
-        XCTAssertEqual(getColorsUseCaseReceivedArguments.intent, .basic, "Wrong getColorsUseCaseReceivedArguments.intent")
+        XCTAssertEqual(getColorsUseCaseReceivedArguments.intent, .support, "Wrong getColorsUseCaseReceivedArguments.intent")
 
         // THEN - GetSpacesUseCase
         XCTAssertEqual(getSpacesUseCaseMock.executeWithLayoutSpacingCallsCount, 1, "getSpacesUseCaseMock.executeWithLayoutSpacing should have been called once")


### PR DESCRIPTION
- Remove .basic case from Intent enum
- Update UseCase switch statements to remove .basic cases
- Update unit tests & snapshots tests